### PR TITLE
adminモデルのログイン機能の作成（Add admin's login-function）

### DIFF
--- a/app/assets/stylesheets/admins.scss
+++ b/app/assets/stylesheets/admins.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admins controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,0 +1,6 @@
+class AdminsController < ApplicationController
+  before_action :authenticate_admin!, only: [:top]
+
+  def top
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  # adminでログイン後のリダイレクト先を指定
+  def after_sign_in_path_for(resource)
+    admins_top_path
+  end
 end

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -1,0 +1,2 @@
+module AdminsHelper
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,6 @@
+class Admin < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end

--- a/app/views/admins/top.html.erb
+++ b/app/views/admins/top.html.erb
@@ -1,0 +1,3 @@
+<h4>管理者用トップページ</h4>
+</br>
+<%= link_to "管理者用ログアウト（仮）", destroy_admin_session_path, method: :delete %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '12f924acbfd6c8c8db48647de3fbc28104e0802d1bac8b8d8cff77f27312b36e5fffc3a9500c17db575c989b9aba5731c33590ad7a6c278611002fa1c6e956d9'
+  # config.secret_key = 'fef8c728b684b1fcb808f09a9db9e980062e89fd00c72e7f4d650672573a0d84871e26ae084cd72fbe2b95fcc5b697b8a012ad999e47c710f45db11de897f4d0'
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -114,7 +114,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = '8c1e9a21eccae9af20c8edbbe3ffb7f485e18795077733ed2267cbdc470ca53ec319d536b9c0e2c0912dba127078c8655d05ab7b7c0421683b3b837c0f644b84'
+  # config.pepper = '745608a557cc053b1d1875963fe160de386309b00cef7deeb23e7e367a8d721ebf14c55588186fc92cfcdf444edc40b557f8b0c6b69af09e8e826be47d686743'
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false
@@ -232,7 +232,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  config.scoped_views = true
+  # config.scoped_views = false
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  devise_for :admins
+  get 'admins/top', to: 'admins#top'
   devise_for :masseurs
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   devise_for :users, controllers: {

--- a/db/migrate/20200327045500_devise_create_admins.rb
+++ b/db/migrate/20200327045500_devise_create_admins.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateAdmins < ActiveRecord::Migration[6.0]
+  def change
+    create_table :admins do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :admins, :email,                unique: true
+    add_index :admins, :reset_password_token, unique: true
+    # add_index :admins, :confirmation_token,   unique: true
+    # add_index :admins, :unlock_token,         unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_25_121958) do
+ActiveRecord::Schema.define(version: 2020_03_27_045500) do
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
 
   create_table "favorites", force: :cascade do |t|
     t.integer "masseur_id"

--- a/test/controllers/admins_controller_test.rb
+++ b/test/controllers/admins_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class AdminsControllerTest < ActionDispatch::IntegrationTest
+  test "should get top" do
+    get admins_top_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/admin_test.rb
+++ b/test/models/admin_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdminTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
●gem deviseを使用したadminモデルのログイン機能追加
●ログインせずにadmins/topにアクセスした場合→admin用ログイン画面に遷移。
●今回はdevise:controllers adminsは作成せず、admins_controllerのみ作成しそちらにtopアクションを入れてあります。
●admins/top(view)におそらく今後不要になるであろうヘッダーやフッターが入ったままになっていますが今回は特に変更は加えておりません。
●動作テスト用に【email: admin@example.com, password: password】でadminを一件登録済。